### PR TITLE
Minor updates to rasterio creation options PR

### DIFF
--- a/src/tophu/_io.py
+++ b/src/tophu/_io.py
@@ -502,6 +502,8 @@ class RasterBand(DatasetReader, DatasetWriter):
         transform : Affine instance, optional
             Affine transformation mapping the pixel space to geographic space.
             Defaults to None.
+        **options : dict, optional
+            Additional driver-specific creation options passed to `rasterio.open`.
         """
         ...
 

--- a/src/tophu/_io.py
+++ b/src/tophu/_io.py
@@ -525,7 +525,9 @@ class RasterBand(DatasetReader, DatasetWriter):
         # If any of `width`, `height`, or `dtype` are provided, all three must be
         # provided. If any were not provided, the dataset must already exist. Otherwise,
         # create the dataset if it did not exist.
-        if (width is None) and (height is None) and (dtype is None):
+        # In addition, `options` may only be provided when creating a new dataset. It
+        # must be an empty dict when opening an existing dataset.
+        if (width is None) and (height is None) and (dtype is None) and (not options):
             mode = "r"
             count = None
         elif (width is not None) and (height is not None) and (dtype is not None):
@@ -553,6 +555,7 @@ class RasterBand(DatasetReader, DatasetWriter):
                         driver: str | None = None,
                         crs: str | dict | rasterio.crs.CRS | None = None,
                         transform: rasterio.transform.Affine | None = None,
+                        **options: dict[str, Any],
                     )
             """).strip()
             raise TypeError(errmsg)


### PR DESCRIPTION
Few minor suggestions:

* Add `**options` to the docstring of `RasterBand.__init__` (second overload)
* Disallow creation options when opening an existing raster